### PR TITLE
Rstudio bug fixed

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -24,9 +24,9 @@ importFrom(tools, md5sum)
 # However, if we include these, ddg.run crashes R when run
 # in RStudio on Windows.  It does not crash on Mac.  It
 # also does not crash on Windows using the standard R environment.
-#importFrom("grDevices", "dev.copy", "dev.copy2pdf", "dev.cur",
-#           "dev.list", "dev.off", "dev.print", "dev.set", "pdf")
-#importFrom("methods", "new")
-#importFrom("utils", "capture.output", "getParseData", "head",
-#           "object.size", "packageVersion", "savehistory", "tail",
-#           "timestamp", "write.csv")
+importFrom("grDevices", "dev.copy", "dev.copy2pdf", "dev.cur",
+           "dev.list", "dev.off", "dev.print", "dev.set", "pdf")
+importFrom("methods", "new")
+importFrom("utils", "capture.output", "getParseData", "head",
+           "object.size", "packageVersion", "savehistory", "tail",
+           "timestamp", "write.csv")


### PR DESCRIPTION
Tested the import namespace functions. Looks like the previous issue no longer exists. Fixes #28 .